### PR TITLE
remove template directive

### DIFF
--- a/jobs/falcon-linux-sensor/templates/bin/pre-start.erb
+++ b/jobs/falcon-linux-sensor/templates/bin/pre-start.erb
@@ -45,7 +45,7 @@ if [[ -f /opt/CrowdStrike/falconctl ]]; then
     FALCON_ARGS+=" --apd=<%= p('falcon.apd') %>"
 <% end -%>
 <% if p("falcon.aph", nil) -%>
-    FALCON_ARGS+=" --apd=false %>"
+    FALCON_ARGS+=" --apd=false"
     FALCON_ARGS+=" --aph=<%= p('falcon.aph') %>"
 <% end -%>
 <% if p("falcon.app", nil) -%>


### PR DESCRIPTION
Remove unnecessary template directive which breaks pre-start script when the script attempts to apply proxy settings using "falconctl"

See issue: [31](https://github.com/CrowdStrike/falcon-boshrelease/issues/31)